### PR TITLE
Update lilygo-t7-s3.json

### DIFF
--- a/platformio/boards/lilygo-t7-s3.json
+++ b/platformio/boards/lilygo-t7-s3.json
@@ -8,7 +8,8 @@
         "core": "esp32",
         "extra_flags": [
             "-DBOARD_HAS_PSRAM",
-            "-DARDUINO_USB_MODE=1"
+            "-DARDUINO_USB_MODE=1",
+            "-DARDUINO_USB_CDC_ON_BOOT=1"
         ],
         "f_cpu": "240000000L",
         "f_flash": "80000000L",
@@ -33,7 +34,7 @@
         "arduino",
         "espidf"
     ],
-    "name": "LILYGO T3-S3",
+    "name": "LILYGO T7-S3",
     "upload": {
         "flash_size": "16MB",
         "maximum_ram_size": 327680,


### PR DESCRIPTION
- Update PlatformIO board definition to enable CDC.
- Fix board name.